### PR TITLE
Fixes game crashing when using /autolec start while not looking at a lectern.

### DIFF
--- a/src/main/java/sys/exe/al/AutoLectern.java
+++ b/src/main/java/sys/exe/al/AutoLectern.java
@@ -270,8 +270,10 @@ public class AutoLectern implements ClientModInitializer {
                     final var intMan = mc.interactionManager;
                     final ClientWorld world;
                     if(intMan != null && plr != null && (world = mc.world) != null) {
-                        plr.networkHandler.sendPacket(new PlayerActionC2SPacket(PlayerActionC2SPacket.Action.ABORT_DESTROY_BLOCK, lecternPos, lecternSide));
-                        world.setBlockBreakingInfo(plr.getId(), lecternPos, -1);
+                        if(this.lecternPos != null) {
+                            plr.networkHandler.sendPacket(new PlayerActionC2SPacket(PlayerActionC2SPacket.Action.ABORT_DESTROY_BLOCK, lecternPos, lecternSide));
+                            world.setBlockBreakingInfo(plr.getId(), lecternPos, -1);
+                        }
                         plr.input = new KeyboardInput(mc.options);
                     }
                     forcedPos = null;


### PR DESCRIPTION
Fixes https://github.com/capthehacker99/AutoLectern/issues/10
Checks if lectern position is valid before attempting to cancel block breaking.